### PR TITLE
Added `metaTechs` option (WIP)

### DIFF
--- a/lib/meta-techs/css.js
+++ b/lib/meta-techs/css.js
@@ -1,0 +1,7 @@
+var stylus = require('enb-stylus/techs/css-stylus');
+
+module.exports = function (opts) {
+    return function (nodeConfig) {
+        nodeConfig.addTech([stylus, { target: opts.target, filesTarget: opts.filesTarget }]);
+    };
+};

--- a/lib/meta-techs/html.js
+++ b/lib/meta-techs/html.js
@@ -1,0 +1,19 @@
+var bemhtml = require('enb-bemxjst/techs/bemhtml-old'),
+    htmlFromBemjson = require('enb-bemxjst/techs/html-from-bemjson');
+
+module.exports = function (opts) {
+    return function (nodeConfig) {
+        nodeConfig.addTechs([
+            [bemhtml, {
+                target: '.bemhtml.js',
+                filesTarget: opts.filesTarget,
+                devMode: false
+            }],
+            [htmlFromBemjson, {
+                target: opts.target,
+                bemhtmlFile: '.bemhtml.js',
+                bemjsonFile: opts.bemjsonFile
+            }]
+        ]);
+    };
+};

--- a/lib/meta-techs/index.js
+++ b/lib/meta-techs/index.js
@@ -1,0 +1,5 @@
+module.exports = {
+    css: require('./css'),
+    js: require('./js'),
+    html: require('./html')
+};

--- a/lib/meta-techs/js.js
+++ b/lib/meta-techs/js.js
@@ -1,0 +1,54 @@
+var files = require('enb-bem-techs/techs/files'),
+    mergeFiles = require('enb/techs/file-merge'),
+    depsByTechToBemdecl = require('enb-bem-techs/techs/deps-by-tech-to-bemdecl'),
+    mergeBemdecl = require('enb-bem-techs/techs/merge-bemdecl'),
+    deps = require('enb-bem-techs/techs/deps-old'),
+    bemhtml = require('enb-bemxjst/techs/bemhtml-old');
+
+module.exports = function (opts) {
+    return function (nodeConfig) {
+        nodeConfig.addTechs([
+            [depsByTechToBemdecl, {
+                target: '.js-bemhtml.bemdecl.js',
+                filesTarget: opts.filesTarget,
+                sourceTech: 'js',
+                destTech: 'bemhtml'
+            }],
+            [depsByTechToBemdecl, {
+                target: '.spec-js-bemhtml.bemdecl.js',
+                filesTarget: opts.filesTarget,
+                sourceTech: 'spec.js',
+                destTech: 'bemhtml'
+            }],
+            [mergeBemdecl, {
+                target: '.browser-bemhtml.bemdecl.js',
+                sources: ['.js-bemhtml.bemdecl.js', '.spec-js-bemhtml.bemdecl.js', opts.bemdeclFile]
+            }],
+
+            [deps, {
+                target: '.browser-bemhtml.deps.js',
+                levelsTarget: opts.levelsTarget,
+                bemdeclFile: '.browser-bemhtml.bemdecl.js'
+            }],
+            [files, {
+                depsFile: '.browser-bemhtml.deps.js',
+                levelsTarget: opts.levelsTarget,
+                filesTarget: '.browser-bemhtml.files',
+                dirsTarget: '.browser-bemhtml.dirs'
+            }],
+
+            [bemhtml, {
+                target: '.browser.bemhtml.js',
+                filesTarget: '.browser-bemhtml.files',
+                devMode: false
+            }]
+        ]);
+
+        nodeConfig.addTechs([
+            [mergeFiles, {
+                target: opts.target,
+                sources: [opts.source, '.browser.bemhtml.js']
+            }]
+        ]);
+    };
+};

--- a/lib/node-configurator.js
+++ b/lib/node-configurator.js
@@ -11,10 +11,6 @@ var path = require('path'),
     mergeBemdecl = require('enb-bem-techs/techs/merge-bemdecl'),
     deps = require('enb-bem-techs/techs/deps-old'),
 
-    bemhtml = require('enb-bemxjst/techs/bemhtml-old'),
-    htmlFromBemjson = require('enb-bemxjst/techs/html-from-bemjson'),
-
-    css = require('enb-stylus/techs/css-stylus'),
     js = require('./techs/borschik-include-js'),
     modules = require('enb-modules/techs/prepend-modules'),
 
@@ -26,7 +22,23 @@ var path = require('path'),
 
 exports.configure = function (config, options) {
     var pattern = path.join(options.destPath, '*'),
-        sourceLevels = [].concat(options.sourceLevels);
+        sourceLevels = [].concat(options.sourceLevels),
+        makeHtml = options.metaTechs.html({
+            target: '?.html',
+            bemjsonFile: '.bemjson.js',
+            filesTarget: '.files'
+        }),
+        makeJs = options.metaTechs.js({
+            target: '.js',
+            source: '.source.js',
+            levelsTarget: '.levels',
+            filesTarget: '.files',
+            bemdeclFile: '.page.bemdecl.js'
+        }),
+        makeCss = options.metaTechs.css({
+            target: '?.css',
+            filesTarget: '.files'
+        });
 
     config.nodes(pattern, function (nodeConfig) {
         var sublevel = path.join(nodeConfig.getNodePath(), 'blocks');
@@ -37,106 +49,82 @@ exports.configure = function (config, options) {
 
         // Base techs
         nodeConfig.addTechs([
-            [levels, { levels: sourceLevels }]
+            [levels, {
+                target: '.levels',
+                levels: sourceLevels
+            }]
         ]);
 
         // Deps
         nodeConfig.addTechs([
-            [provide, { target: '?.bemjson.js' }],
-            [provide, { target: '?.base.bemdecl.js' }],
+            [provide, { target: '.bemjson.js' }],
+            [provide, { target: '.base.bemdecl.js' }],
 
-            [bemjsonToBemdecl, { target: '?.bemjson.bemdecl.js' }],
+            [bemjsonToBemdecl, {
+                source: '.bemjson.js',
+                target: '.page.bemdecl.js'
+            }],
             [depsByTechToBemdecl, {
-                target: '?.spec-js.bemdecl.js',
-                filesTarget: '?.base.files',
+                target: '.spec-js.bemdecl.js',
+                filesTarget: '.base.files',
                 sourceTech: 'spec.js',
                 destTech: 'js'
             }],
             [mergeBemdecl, {
-                target: '?.bemdecl.js',
-                sources: ['?.base.bemdecl.js', '?.bemjson.bemdecl.js', '?.spec-js.bemdecl.js']
+                target: '.bemdecl.js',
+                sources: ['.base.bemdecl.js', '.page.bemdecl.js', '.spec-js.bemdecl.js']
             }],
 
-            [deps]
+            [deps, {
+                target: '.deps.js',
+                bemdeclFile: '.bemdecl.js',
+                levelsTarget: '.levels'
+            }]
         ]);
 
         // Files
         nodeConfig.addTechs([
             [files, {
-                depsFile: '?.base.bemdecl.js',
-                depsFormat: 'bemdecl.js',
-                filesTarget: '?.base.files',
-                dirsTarget: '?.base.dirs'
-            }],
-            [files]
-        ]);
-
-        // Client BEMHTML
-        nodeConfig.addTechs([
-            [depsByTechToBemdecl, {
-                target: '?.js.bemhtml.bemdecl.js',
-                sourceTech: 'js',
-                destTech: 'bemhtml'
-            }],
-            [depsByTechToBemdecl, {
-                target: '?.spec-js.bemhtml.bemdecl.js',
-                sourceTech: 'spec.js',
-                destTech: 'bemhtml'
-            }],
-            [mergeBemdecl, {
-                target: '?.bemhtml.bemdecl.js',
-                sources: ['?.js.bemhtml.bemdecl.js', '?.spec-js.bemhtml.bemdecl.js', '?.bemjson.bemdecl.js']
-            }],
-
-            [deps, {
-                target: '?.bemhtml.deps.js',
-                sourceDepsFile: '?.bemhtml.bemdecl.js'
+                depsFile: '.base.bemdecl.js',
+                levelsTarget: '.levels',
+                filesTarget: '.base.files',
+                dirsTarget: '.base.dirs'
             }],
             [files, {
-                depsFile: '?.bemhtml.deps.js',
-                filesTarget: '?.bemhtml.files',
-                dirsTarget: '?.bemhtml.dirs'
-            }],
-
-            [bemhtml, {
-                target: '?.browser.bemhtml.js',
-                filesTarget: '?.bemhtml.files',
-                devMode: false
+                depsFile: '.deps.js',
+                levelsTarget: '.levels',
+                filesTarget: '.files',
+                dirsTarget: '.dirs'
             }]
-        ]);
-
-        // HTML
-        nodeConfig.addTechs([
-            [bemhtml, { devMode: false }],
-            [htmlFromBemjson]
         ]);
 
         // Browser JS
         nodeConfig.addTechs([
             [js, {
                 sourceSuffixes: options.jsSuffixes,
-                target: '?.source.browser.js'
+                target: '.pure.js',
+                filesTarget: '.files'
             }],
             [modules, {
-                target: '?.browser.js',
-                source: '?.source.browser.js'
+                target: '.source.js',
+                source: '.pure.js'
             }],
             [js, {
-                target: '?.pure.spec.js',
+                target: '.pure.spec.js',
                 sourceSuffixes: ['spec.js'],
-                filesTarget: '?.base.files'
+                filesTarget: '.base.files'
             }],
             [mergeFiles, {
-                target: '?.pre.spec.js',
-                sources: ['?.browser.js', '?.bemhtml.js', '?.pure.spec.js']
+                target: '.spec.js',
+                sources: ['.js', '.pure.spec.js']
             }]
         ]);
 
         if (NEED_COVERAGE) {
             nodeConfig.addTechs([
                 [borschik, {
-                    source: '?.pre.spec.js',
-                    target: '?.coverage.spec.js',
+                    source: '.spec.js',
+                    target: '.coverage.spec.js',
                     tech: borschikTechIstanbulPath,
                     techOptions: {
                         instrumentPaths: options.levels.map(function (level) {
@@ -148,14 +136,14 @@ exports.configure = function (config, options) {
                     minify: false
                 }],
                 [copy, {
-                    source: '?.coverage.spec.js',
+                    source: '.coverage.spec.js',
                     target: '?.spec.js'
                 }]
             ]);
         } else {
             nodeConfig.addTech(
                 [borschik, {
-                    source: '?.pre.spec.js',
+                    source: '.spec.js',
                     target: '?.spec.js',
                     freeze: true,
                     minify: false
@@ -163,11 +151,12 @@ exports.configure = function (config, options) {
             );
         }
 
-        // CSS
-        nodeConfig.addTech(css);
+        makeHtml(nodeConfig);
+        makeJs(nodeConfig);
+        makeCss(nodeConfig);
 
         nodeConfig.addTargets([
-            '?.spec.js', '?.css', '?.html'
+            '?.css', '?.spec.js', '?.html'
         ]);
     });
 };

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -6,7 +6,8 @@ var path = require('path'),
     scanner = require('enb-bem-pseudo-levels/lib/level-scanner'),
     runner = require('./runner'),
     configurator = require('./node-configurator'),
-    deps = require('enb-bem-techs/lib/deps/deps');
+    deps = require('enb-bem-techs/lib/deps/deps'),
+    metaTechs = require('./meta-techs');
 
 module.exports = function (helper) {
     return {
@@ -27,6 +28,10 @@ module.exports = function (helper) {
 
                 return level;
             });
+            options.metaTechs || (options.metaTechs = {});
+            options.metaTechs.css || (options.metaTechs.css = metaTechs.css);
+            options.metaTechs.js || (options.metaTechs.js = metaTechs.js);
+            options.metaTechs.html || (options.metaTechs.html = metaTechs.html);
 
             helper.prebuild(function (magic) {
                 return scanner.scan(options.levels)
@@ -56,8 +61,8 @@ module.exports = function (helper) {
                         return vow.all(Object.keys(nodes).map(function (node) {
                             var basename = path.basename(node),
                                 dirname = path.join(dstpath, basename),
-                                bemdeclFilename = path.join(dirname, basename + '.base.bemdecl.js'),
-                                bemjsonFilename = path.join(dirname, basename + '.bemjson.js'),
+                                bemdeclFilename = path.join(dirname, '.base.bemdecl.js'),
+                                bemjsonFilename = path.join(dirname, '.bemjson.js'),
                                 notation = naming.parse(basename),
                                 dep = { block: notation.block },
                                 bemdeclSource,


### PR DESCRIPTION
Resolved #11 

* Moved make `?.css`, `?.js` and `?.html` targets to `lib/meta-techs`.
* Added `metaTechs` option.

**Example:**

```js
var cssTech = require('enb/techs/css');

module.exports = function (config) {
    config.includeConfig('enb-bem-specs');

    var specs = config.module('enb-bem-specs').createConfigurator('specs');

    specs.configure({
        destPath: 'set.specs',
        levels: ['blocks'],
        sourceLevels: [
            { path: '../libs/bem-core/common.blocks', check: false },
            { path: '../libs/bem-pr/spec.blocks', check: false },
            { path: 'blocks', check: true }
        ],
        metaTechs: {
            css: metaCss
        }
    });
};

// make `?.css` with `cssTech`
function metaCss(opts) {
    return function (nodeConfig) {
        nodeConfig.addTech([cssTech, { 
            target: opts.target, 
            filesTarget: opts.filesTarget 
        }]);
    };
};
```