### PR TITLE
Fixed bug with measure coverage for `?.spec.js`

### DIFF
--- a/lib/node-configurator.js
+++ b/lib/node-configurator.js
@@ -16,7 +16,9 @@ var path = require('path'),
     htmlFromBemjson = require('enb-bemxjst/techs/html-from-bemjson'),
 
     css = require('enb-stylus/techs/css-stylus'),
-    js = require('./techs/borschik-include-js'),
+
+    js = require('enb/techs/js'),
+    borschikJs = require('./techs/borschik-include-js'),
     modules = require('enb-modules/techs/prepend-modules'),
 
     borschik = require('enb-borschik/techs/borschik'),
@@ -114,7 +116,7 @@ exports.configure = function (config, options) {
 
         // Browser JS
         nodeConfig.addTechs([
-            [js, {
+            [borschikJs, {
                 sourceSuffixes: options.jsSuffixes,
                 target: '?.source.browser.js'
             }],


### PR DESCRIPTION
Used `enb/techs/js` tech for `*.spec.js` files. This way *.spec.js file does not get instrumented.

Resolved #25 