### PR TITLE
Added support fot omitting code of module system

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ module.exports = function (config) {
 * *String[]* `specSuffixes` &mdash;&nbsp;суффиксы `spec.js`-файлов БЭМ-сущностей. По&nbsp;умолчанию&nbsp;&mdash;&nbsp;`['spec.js']`.
 * *String|Function* `depsTech` — технология для раскрытия зависимостей. По умолчанию — `deps-old`.
 * *Boolean* `langs` — включает в сборку `i18n`.
+* *Boolean* `omitModules` — не добавлет в собираемый файл код модульной системы `ym` (нужен для случаев, когда этот код уже подключается в другом файле). По&nbsp;умолчанию&nbsp;&mdash;&nbsp;`false`.
 
 Запуск из консоли
 -----------------

--- a/lib/node-configurator.js
+++ b/lib/node-configurator.js
@@ -152,7 +152,7 @@ exports.configure = function (config, options) {
                     '?.source.browser.js', '?.browser.bemhtml.js', '?.pure.spec.js'
                 )
             }],
-            [modules, {
+            [options.omitModules ? copy : modules, {
                 target: '?.pre.spec.js',
                 source: '?.prepared.spec.js'
             }]


### PR DESCRIPTION
For example (example uses `script` from https://github.com/enb-bem/enb-bem-specs/pull/42):
```js
specs.configure({
	...
	scripts: ['https://yastatic.net/jquery/1.8.3/jquery.min.js',
			'https://yastatic.net/lodash/2.4.1/lodash.min.js',
			// В этом файле уже есть код модульной системы
			'../../../bundles/common/yamoney-lib/_yamoney-lib.js'],
	omitModules: true
});
```